### PR TITLE
Split input text into lines delimited by CRLF (as in Windows) as well as by LF

### DIFF
--- a/spec/example-blocks-spec.js
+++ b/spec/example-blocks-spec.js
@@ -1,0 +1,17 @@
+/*global describe, it, expect, require */
+describe('ExampleBlocks', function () {
+	'use strict';
+	var ExampleBlocks = require('../src/example-blocks');
+	it('should split lines delimited by LF', function () {
+		var blocks = new ExampleBlocks('Line 1\nLine 2\nLine 3').getBlocks();
+		expect(blocks.map(function (block) {
+			return block.getMatchText();
+		})).toEqual([ ['Line 1'], ['Line 2'], ['Line 3'] ]);
+	});
+	it('should split lines delimited by CRLF', function () {
+		var blocks = new ExampleBlocks('Line 1\r\nLine 2\r\nLine 3').getBlocks();
+		expect(blocks.map(function (block) {
+			return block.getMatchText();
+		})).toEqual([ ['Line 1'], ['Line 2'], ['Line 3'] ]);
+	});
+});

--- a/src/example-blocks.js
+++ b/src/example-blocks.js
@@ -4,7 +4,7 @@ module.exports = function ExampleBlocks(inputText) {
 	var self = this,
 		ExampleBlock = require('./example-block');
 	self.getBlocks = function () {
-		var lines = inputText && inputText.split('\n').reverse(),
+		var lines = inputText && inputText.split(/\r?\n/).reverse(),
 			current = new ExampleBlock(),
 			blocks = [current];
 		lines.forEach(function (line) {


### PR DESCRIPTION
A simple solution to the problem of dealing with text files delimited by CRLF as in Windows (see [issue 2](https://github.com/daspec/daspec-js/issues/2)).

There is a unit test but if you change any of the test data files to use CRLF delimiters, tests of those files fail. I am not sure how to fix that.